### PR TITLE
Performance improvements

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -119,26 +119,19 @@ module RspecPuppetFacts
     # facter data (see FacterDB 0.5.2 for Facter releases 3.8 and 3.9). In this situation we need to
     # cycle through and downgrade Facter versions per platform type until we find matching Facter data.
     filter.each do |filter_spec|
-      facter_version_filter = RspecPuppetFacts.facter_version_to_filter(facterversion)
-      db = FacterDB.get_facts(filter_spec.merge({ :facterversion =>  facter_version_filter }))
+      version = FacterDB.get_facts(filter_spec).map { |facts| Gem::Version.new(facts[:facterversion]) }.sort.reverse.detect { |v| v <= facterversion_obj }
+      next unless version
+      version = version.to_s
 
-      if db.empty?
+      unless version == facterversion
         if RspecPuppetFacts.spec_facts_strict?
           raise ArgumentError, "No facts were found in the FacterDB for Facter v#{facterversion} on #{filter_spec}, aborting"
         end
 
-        version = FacterDB.get_facts(filter_spec).map { |facts| Gem::Version.new(facts[:facterversion]) }.sort.reverse.detect { |v| v <= facterversion_obj }
-
-        next unless version
-        version = version.to_s
-        facter_version_filter = "/\\A#{Regexp.escape(version)}/"
-
-        unless version == facterversion
-          RspecPuppetFacts.warning "No facts were found in the FacterDB for Facter v#{facterversion} on #{filter_spec}, using v#{version} instead"
-        end
+        RspecPuppetFacts.warning "No facts were found in the FacterDB for Facter v#{facterversion} on #{filter_spec}, using v#{version} instead"
       end
 
-      filter_spec[:facterversion] = facter_version_filter
+      filter_spec[:facterversion] = "/\\A#{Regexp.escape(version)}/"
     end
 
     received_facts = FacterDB::get_facts(filter)


### PR DESCRIPTION
This includes some performance improvements that reduce the loading of tests by about 4 seconds (from ~11 to ~7 seconds) so about a third.

There are some gotchas. Each commit captures what it does. Copying for readability.

# f39009f Move facterversion_obj declaration out of the loop

There's a very good chance we'll need this object and this saves parsing it over and over.

This is a safe patch.

# 5452fe9 Do not query for the exact facter version

This assumes that no exact match can be found in most cases. This saves a call to Facterdb. Some testing on puppet-nginx this reduced the time for a dry run by about 1 to 2 seconds, from about ~11 to ~9 seconds.

Actual results will vary on the FacterDB. Note that a new Facter version will trigger the bad code unless all operating systems are updated so this is a very likely code path.

It also makes the easier to read.

This appears to be backwards incompatible. I didn't expect it, but it looks like you can query for 3.1.2 and get back 3.1.6 in the current releases while I assumed that was impossible.

# 4d80729 Collect facts iteratively

Rather than getting the facts for every filter spec and then discarding that, this stores the found facts in an array and uses that.

This eliminates a call to FacterDB::get_facts with a very complex filter.

A quick test in puppet-nginx reduces loading of tests by about 2 seconds (from ~9 to ~7).

This should be fairly safe. The order of the results is now likely to be different and perhaps that's causing test failures.

Fixes #123