### PR TITLE
Add a describe_on_supported_os DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,23 @@ describe 'myclass' do
 end
 ```
 
+```ruby
+require 'spec_helper'
+
+describe_on_supported_os 'myclass' do
+  it { is_expected.to compile.with_all_deps }
+  ...
+
+  # If you need any to specify any operating system specific tests
+  case metadata[:os_facts][:osfamily]
+  when 'Debian'
+    ...
+  else
+    ...
+  end
+end
+```
+
 When using roles and profiles to manage a heterogeneous IT estate, you can test a profile that supports several OSes with many `let(:facts)` as long as each is in its own context:
 ```ruby
 require 'spec_helper'

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -390,7 +390,25 @@ module RspecPuppetFacts
   ensure
     fd.close if fd
   end
+
+  module DSL
+    def describe_on_supported_os(*args, &block)
+      describe(*args) do
+        # TODO: assumes RspecPuppetFacts was included
+        on_supported_os.each do |os, os_facts|
+          context("on #{os}") do
+            let(:facts) { os_facts }
+
+            class_exec(&block)
+          end
+        end
+      end
+    end
+  end
 end
+
+RSpec::Core::ExampleGroup.extend(RspecPuppetFacts::DSL)
+RSpec::Core::DSL.expose_example_group_alias(:describe_on_supported_os)
 
 RSpec.configure do |c|
   c.add_setting :default_facter_version,


### PR DESCRIPTION
It is quite tedious to write the `on_supported_os` loop in every file. This defines a short hand in the RSpec DSL. To keep access to the OS facts, it is added to the metadata.

This is a bit hacky, but I'm submitting it here for consideration. The naming may also be confusing and perhaps there's a better name.

There are also limitations. It's no longer possible to pass a select number of operating systems.