### PR TITLE
Use structured facts to detect OS version

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -156,7 +156,7 @@ module RspecPuppetFacts
         operatingsystemmajrelease = facts[:operatingsystemrelease]
       elsif facts[:operatingsystem] == 'windows' && facts[:operatingsystemrelease].start_with?('10.0.')
         operatingsystemmajrelease = '2016'
-      elsif !facts.dig(:os, 'release', 'major').nil?
+      elsif facts.dig(:os, 'release', 'major')
         operatingsystemmajrelease = facts[:os]['release']['major']
       else
         if facts[:operatingsystemmajrelease].nil?

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -149,12 +149,15 @@ module RspecPuppetFacts
     os_facts_hash = {}
     received_facts.map do |facts|
       # Fix facter bug
+      # Todo: refactor the whole block to rely on structured facts and use legacy facts as fallback
       if facts[:operatingsystem] == 'Ubuntu'
         operatingsystemmajrelease = facts[:operatingsystemrelease].split('.')[0..1].join('.')
       elsif facts[:operatingsystem] == 'OpenBSD'
         operatingsystemmajrelease = facts[:operatingsystemrelease]
       elsif facts[:operatingsystem] == 'windows' && facts[:operatingsystemrelease].start_with?('10.0.')
         operatingsystemmajrelease = '2016'
+      elsif !facts.dig(:os, 'release', 'major').nil?
+        operatingsystemmajrelease = facts[:os]['release']['major']
       else
         if facts[:operatingsystemmajrelease].nil?
           operatingsystemmajrelease = facts[:operatingsystemrelease].split('.')[0]


### PR DESCRIPTION
This is at least required for Arch Linux on Facter 4. It doesn't have
the legacy facts operatingsystemmajrelease / operatingsystemrelease.

https://tickets.puppetlabs.com/projects/FACT/issues/FACT-3114