### PR TITLE
Collect facts iteratively

### DIFF
--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -662,19 +662,16 @@ describe RspecPuppetFacts do
 
       before do
         allow(described_class).to receive(:warning).with(a_string_matching(/no facts were found/i))
-        allow(FacterDB).to receive(:get_facts).and_call_original
       end
 
       it 'escapes the parens in the filter' do
-        filter = [
-          include(
-            :operatingsystem        => "IOS",
-            :operatingsystemrelease => "/^12\\.2\\(25\\)EWA9/",
-            :hardwaremodel          => "x86_64",
-          ),
-        ]
+        filter = {
+          :operatingsystem        => "IOS",
+          :operatingsystemrelease => "/^12\\.2\\(25\\)EWA9/",
+          :hardwaremodel          => "x86_64",
+        }
 
-        expect(FacterDB).to receive(:get_facts).with(filter)
+        expect(FacterDB).to receive(:get_facts).with(filter).once
         subject
       end
 


### PR DESCRIPTION
Rather than getting the facts for every filter spec and then discarding that, this stores the found facts in an array and uses that.

This eliminates a call to FacterDB::get_facts with a very complex filter.

A quick test in puppet-nginx reduces loading of tests by about 2 seconds (from ~9 to ~7).

This is a reworked version of https://github.com/voxpupuli/rspec-puppet-facts/pull/124 for a clean changelog. It requires https://github.com/voxpupuli/rspec-puppet-facts/pull/151 to be merged first.