### PR TITLE
(feat) -  Add merge facts option to add_custom_fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,28 @@ To do this, pass a lambda as the value for the custom fact. The lambda is passed
 add_custom_fact :root_home, lambda { |os,facts| "/tmp/#{facts['hostname']}" }
 ```
 
+#### Merge into existing facts
+
+You can also supply an optional input `:merge_facts` to the `add_custom_fact` method.
+
+This allows you to merge facts values into a fact, if the fact is already present in the facts hash as oppose to overwriting the fact value.
+
+```ruby
+add_custom_fact :identity, { 'user' => 'test_user' }, merge_facts: true
+```
+
+Will result in a hash of the identity fact like the below:
+
+```ruby
+{
+  "gid"=>0,
+  "group"=>"root",
+  "privileged"=>true,
+  "uid"=>0,
+  "user"=>"test_user"
+}
+```
+
 ### Supplying Custom External Facts through FacterDB
 Rspec-puppet-facts uses a gem called facterdb that contains many fact sets of various combinations that are pre generated.  Rspec-puppet-facts queries
 facterdb to pull out a specific fact set to use when testing.

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -2,6 +2,7 @@ require 'puppet'
 require 'facter'
 require 'facterdb'
 require 'json'
+require 'deep_merge'
 
 # The purpose of this module is to simplify the Puppet
 # module's RSpec tests by looping through all supported

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -228,7 +228,13 @@ module RspecPuppetFacts
       next if fact[:options][:confine] && !fact[:options][:confine].include?(os)
       next if fact[:options][:exclude] && fact[:options][:exclude].include?(os)
 
-      facts[name] = fact[:value].respond_to?(:call) ? fact[:value].call(os, facts) : fact[:value]
+      value = fact[:value].respond_to?(:call) ? fact[:value].call(os, facts) : fact[:value]
+      # if merge_facts passed, merge supplied facts into facts hash
+      if fact[:options][:merge_facts]
+        facts.deep_merge!({name => value})
+      else
+        facts[name] = value
+      end
     end
 
     facts

--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'voxpupuli-rubocop', '~> 2.4.0'
 
+  s.add_runtime_dependency 'deep_merge', '~> 1.2'
   s.add_runtime_dependency 'facter', '< 5'
   s.add_runtime_dependency 'facterdb', '>= 0.5.0', '< 2'
   s.add_runtime_dependency 'puppet', '>= 7', '< 9'

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -902,6 +902,26 @@ describe RspecPuppetFacts do
       expect(subject['redhat-7-x86_64'][:root_home]).to eq '/root'
     end
 
+    it 'merges a fact value into fact when merge_facts passed' do
+      add_custom_fact :identity, { 'user' => 'test_user' }, merge_facts: true
+      expect(subject['redhat-7-x86_64'][:identity]).to eq(
+      {
+        "gid"=>0,
+        "group"=>"root",
+        "privileged"=>true,
+        "uid"=>0,
+        "user"=>"test_user"
+      })
+    end
+
+    it 'overwrites fact' do
+      add_custom_fact :identity, { 'user' => 'other_user' }
+      expect(subject['redhat-7-x86_64'][:identity]).to eq(
+      {
+        "user"=>"other_user"
+      })
+    end
+
     it 'confines a fact to a particular operating system' do
       add_custom_fact 'root_home', '/root', :confine => 'redhat-7-x86_64'
       expect(subject['redhat-7-x86_64'][:root_home]).to eq '/root'


### PR DESCRIPTION
This PR implements a new merge_facts option, which can be used with the add_custom_fact method in your configurations.
It allows users to determine whether they want to completely overwrite a fact already present in the facts hash, or simply merge values into the existing fact to expand/overwrite certain values whilst the entirety of the fact.

sample usage:
add_custom_fact :identity, { 'user' => "test_user" }, merge_facts: true
will update the value of user in the identity fact to "test_user", whilst keeping the rest of the identity fact values the same.

Failing tests rely on the merge of https://github.com/voxpupuli/rspec-puppet-facts/pull/157