### PR TITLE
voxpupuli-rubocop: Pin to patch version

### DIFF
--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'yard'
 
-  s.add_development_dependency 'voxpupuli-rubocop', '~> 2.0'
+  s.add_development_dependency 'voxpupuli-rubocop', '~> 2.4.0'
 
   s.add_runtime_dependency 'facter'
   s.add_runtime_dependency 'facterdb', '>= 0.5.0'


### PR DESCRIPTION
We do this on all other projects as well. New minor version might pull in new rubocop versions. To ensure that we test those in a PR, we pin to the patch release. dependabot will inform us about updates.