### PR TITLE
Gemfile: Add faraday as github_changelog_generator dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ gemspec
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false
 
 group :release do
-  gem 'github_changelog_generator', require: false
+  gem 'faraday-retry', '~> 2.1', require: false
+  gem 'github_changelog_generator', '~> 1.16.4', require: false
 end
 
 group :coverage, optional: ENV['COVERAGE']!='yes' do


### PR DESCRIPTION
faraday is an optional dependency. In all other projects we add it as well to the Gemfile. Otherwise GCG prints a warning.