### PR TITLE
gemspec: Add version constraints & CI: Build gem in strict mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           BUNDLE_WITHOUT: release
       - name: Build gem
-        run: gem build *.gemspec
+        run: gem build --strict --verbose *.gemspec
       - name: Publish gem to rubygems.org
         run: gem push *.gem
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Test against Puppet component versions
         run: bundle exec rake puppet_versions:test
       - name: Test gem build
-        run: bundle exec rake build
+        run: gem build --strict --verbose *.gemspec
 
   tests:
     needs:

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-require 'bundler/gem_tasks'
-
 PUPPET_VERSIONS_PATH = File.join(__dir__, 'ext', 'puppet_agent_components.json')
 
 begin

--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -18,14 +18,14 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_development_dependency 'mime-types'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'yard'
+  s.add_development_dependency 'mime-types', '~> 3.5', '>= 3.5.2'
+  s.add_development_dependency 'rake', '~> 13.1'
+  s.add_development_dependency 'rspec', '~> 3.12'
+  s.add_development_dependency 'yard', '~> 0.9.34'
 
   s.add_development_dependency 'voxpupuli-rubocop', '~> 2.4.0'
 
-  s.add_runtime_dependency 'facter'
-  s.add_runtime_dependency 'facterdb', '>= 0.5.0'
-  s.add_runtime_dependency 'puppet'
+  s.add_runtime_dependency 'facter', '< 5'
+  s.add_runtime_dependency 'facterdb', '>= 0.5.0', '< 2'
+  s.add_runtime_dependency 'puppet', '>= 7', '< 9'
 end


### PR DESCRIPTION
We started with this in other gems as well. This allows us to build gems in strict mode.