### PR TITLE
Rely on modern facts

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -82,16 +82,12 @@ module RspecPuppetFacts
                                     "/^#{operatingsystemmajrelease}-/"
                                   end
             when /Windows/i
-              hardwaremodel = /^[12]\./.match?(facterversion) ? 'x64' : 'x86_64'
+              hardwaremodel = 'x86_64'
               os_sup['operatingsystem'] = os_sup['operatingsystem'].downcase
               operatingsystemmajrelease = operatingsystemmajrelease[/\A(?:Server )?(.+)/i, 1]
 
               # force quoting because windows releases can contain spaces
               os_release_filter = "\"#{operatingsystemmajrelease}\""
-
-              if operatingsystemmajrelease == '2016' && Puppet::Util::Package.versioncmp(facterversion, '3.4') < 0
-                os_release_filter = '/^10\\.0\\./'
-              end
             when /Amazon/i
               # Tighten the regex for Amazon Linux 2 so that we don't pick up Amazon Linux 2016 or 2017 facts
               os_release_filter = "/^2$/" if operatingsystemmajrelease == '2'

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -94,17 +94,17 @@ module RspecPuppetFacts
             end
 
             filter << {
-                :operatingsystem        => os_sup['operatingsystem'],
-                :operatingsystemrelease => os_release_filter,
-                :hardwaremodel          => hardwaremodel,
+              'os.name' => os_sup['operatingsystem'],
+              'os.release.full' => os_release_filter,
+              'os.hardware' => hardwaremodel,
             }
           end
         end
       else
         opts[:hardwaremodels].each do |hardwaremodel|
           filter << {
-              :operatingsystem => os_sup['operatingsystem'],
-              :hardwaremodel   => hardwaremodel,
+            'os.name' => os_sup['operatingsystem'],
+            'os.hardware' => hardwaremodel,
           }
         end
       end
@@ -144,26 +144,13 @@ module RspecPuppetFacts
 
     os_facts_hash = {}
     received_facts.map do |facts|
-      # Fix facter bug
-      # Todo: refactor the whole block to rely on structured facts and use legacy facts as fallback
-      if facts[:operatingsystem] == 'Ubuntu'
-        operatingsystemmajrelease = facts[:operatingsystemrelease].split('.')[0..1].join('.')
-      elsif facts[:operatingsystem] == 'OpenBSD'
-        operatingsystemmajrelease = facts[:operatingsystemrelease]
-      elsif facts[:operatingsystem] == 'windows' && facts[:operatingsystemrelease].start_with?('10.0.')
-        operatingsystemmajrelease = '2016'
-      elsif facts.dig(:os, 'release', 'major')
-        operatingsystemmajrelease = facts[:os]['release']['major']
-      elsif facts.dig(:os, 'distro', 'release', 'major')
-        operatingsystemmajrelease = facts[:os]['distro']['release']['major']
-      else
-        if facts[:operatingsystemmajrelease].nil?
-          operatingsystemmajrelease = facts[:operatingsystemrelease].split('.')[0]
-        else
-          operatingsystemmajrelease = facts[:operatingsystemmajrelease]
-        end
+      os_fact = facts[:os]
+      unless os_fact
+        RspecPuppetFacts.warning "No os fact was found in FacterDB for: #{facts}"
+        next
       end
-      os = "#{facts[:operatingsystem].downcase}-#{operatingsystemmajrelease}-#{facts[:hardwaremodel]}"
+
+      os = "#{os_fact['name'].downcase}-#{os_fact['release']['major']}-#{os_fact['hardware']}"
       next if RspecPuppetFacts.spec_facts_os_filter && !os.start_with?(RspecPuppetFacts.spec_facts_os_filter)
       facts.merge! RspecPuppetFacts.common_facts
       os_facts_hash[os] = RspecPuppetFacts.with_custom_facts(os, facts)

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -377,11 +377,11 @@ describe RspecPuppetFacts do
               {
                 "operatingsystem" => "FreeBSD",
                 "operatingsystemrelease" => [
-                  "10",
+                  "13",
                 ],
               },
             ],
-            :facterversion => '2.4',
+            :facterversion => '4.5',
           },
         )
       }
@@ -396,7 +396,7 @@ describe RspecPuppetFacts do
 
       it 'returns supported OS' do
         expect(subject.keys.sort).to eq [
-          'freebsd-10-amd64',
+          'freebsd-13-amd64',
         ]
       end
     end
@@ -409,11 +409,11 @@ describe RspecPuppetFacts do
               {
                 "operatingsystem" => "OpenBSD",
                 "operatingsystemrelease" => [
-                  "5.7",
+                  "7.5",
                 ],
               },
             ],
-            :facterversion => '2.4',
+            :facterversion => '4.7',
           },
         )
       }
@@ -428,12 +428,12 @@ describe RspecPuppetFacts do
 
       it 'returns supported OS' do
         expect(subject.keys.sort).to eq [
-          'openbsd-5.7-amd64',
+          'openbsd-7-amd64',
         ]
       end
     end
 
-    context 'When testing Solaris 11', :if => Facter.version.to_f >= 2.0 do
+    context 'When testing Solaris 11' do
       subject {
         on_supported_os(
             {
@@ -498,7 +498,7 @@ describe RspecPuppetFacts do
       end
     end
 
-    context 'When testing Windows', :if => Facter.version.to_f >= 2.4 do
+    context 'When testing Windows' do
       subject do
         on_supported_os(
           {
@@ -616,7 +616,7 @@ describe RspecPuppetFacts do
                 "operatingsystem" => "Archlinux",
               },
             ],
-            :facterversion => '2.4',
+            :facterversion => '3.14',
           },
         )
       }
@@ -654,9 +654,9 @@ describe RspecPuppetFacts do
 
       it 'escapes the parens in the filter' do
         filter = {
-          :operatingsystem        => "IOS",
-          :operatingsystemrelease => "/^12\\.2\\(25\\)EWA9/",
-          :hardwaremodel          => "x86_64",
+          'os.name'         => "IOS",
+          'os.release.full' => "/^12\\.2\\(25\\)EWA9/",
+          'os.hardware'     => "x86_64",
         }
 
         expect(FacterDB).to receive(:get_facts).with(filter).once
@@ -701,19 +701,19 @@ describe RspecPuppetFacts do
           supported_os: [
             { 'operatingsystem' => 'CentOS', 'operatingsystemrelease' => %w[7] },
           ],
-          facterversion: "2.6",
+          facterversion: "3.15",
         )
       end
 
       before do
-        allow(Facter).to receive(:version).and_return('2.4.5')
+        allow(Facter).to receive(:version).and_return('3.14.1')
       end
 
 
       it 'returns facts from a facter version matching version and below' do
         is_expected.to match(
           'centos-7-x86_64' => include(
-            :facterversion => /\A2\.[0-6]\./,
+            :facterversion => /\A3\.14\./,
           ),
         )
       end
@@ -797,23 +797,6 @@ describe RspecPuppetFacts do
       end
     end
 
-    context 'When querying a fact set that does not have an operatingsystemmajrelease fact' do
-      subject do
-        on_supported_os(
-          supported_os: [
-            { 'operatingsystem' => 'SLES', 'operatingsystemrelease' => ['11'] },
-          ],
-          facterversion: '2.1.0',
-        )
-      end
-
-      it 'splits the operatingsystemrelease fact value to get the major release' do
-        is_expected.to match(
-          'sles-11-x86_64' => include(:operatingsystemrelease => '11.3'),
-        )
-      end
-    end
-
     context 'With an invalid facterversion in the options hash' do
       let(:method_call) do
         on_supported_os(
@@ -844,7 +827,7 @@ describe RspecPuppetFacts do
       before do
         allow(FacterDB).to receive(:get_facts).and_call_original
         allow(FacterDB).to receive(:get_facts).with(
-          {:operatingsystem=>"CentOS", :operatingsystemrelease=>"/^7/", :hardwaremodel=>"x86_64"},
+          {'os.name'=>"CentOS", 'os.release.full'=>"/^7/", 'os.hardware'=>"x86_64"},
         ).and_wrap_original do |m, *args|
           m.call(*args).reject { |facts| facts[:facterversion].start_with?('3.9.') }
         end

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -546,18 +546,6 @@ describe RspecPuppetFacts do
         it { is_expected.to have_attributes(:size => 1) }
         it { is_expected.to include('windows-2016-x86_64' => an_instance_of(Hash)) }
       end
-
-      context 'with a 2016 release and Facter < 3.4' do
-        let(:release) { ['2016'] }
-        let(:facterversion) { '3.3.0' }
-
-        it { is_expected.to be_a(Hash) }
-        it { is_expected.to have_attributes(:size => 1) }
-
-        it 'munges the operatingsystemmajrelease to 2016' do
-          is_expected.to include('windows-2016-x86_64' => an_instance_of(Hash))
-        end
-      end
     end
 
     context 'When operatingsystemrelease has space' do


### PR DESCRIPTION
Previously it read legacy facts, which are deprecated and slowly going away. It drops all the various hacks that were needed for older versions on the assumption they're no longer needed.

Facter 2.4 introduced the structured os fact while Facter 3.0 added the os.hardware fact to it. rspec-puppet-facts relies on those, so Facter versions older than 3.0 are no longer supported.

It also drops workarounds for Facter < 3.4 on Windows.