### PR TITLE
Rewrite facter_version_for_puppet_version for a better style

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -412,7 +412,7 @@ module RspecPuppetFacts
       return Facter.version
     end
 
-    applicable_versions.sort { |a, b| b.first <=> a.first }.first.last
+    applicable_versions.max_by { |p, _| p }.last
   rescue JSON::ParserError
     warning "#{json_path} contains invalid JSON, defaulting to Facter #{Facter.version}"
     Facter.version


### PR DESCRIPTION
This rewrites the code to be easier to follow.

First of all, JSON is parsed and all error handling is local. Using a self closing block avoids having to close a file descriptor and exception handling near the actual code helps understanding.

Then it uses filter_map that Ruby 2.7 introduced to avoid calling .map.compact. It also moves the selection of applicable versions into the mapping.

Includes https://github.com/voxpupuli/rspec-puppet-facts/pull/181.