### PR TITLE
Make Puppet a soft dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,6 @@ end
 # openvox on Ruby 3.3 / 3.4 has some missing dependencies
 # Will be fixed in a future openvox release
 gem 'base64', '~> 0.2' if RUBY_VERSION >= '3.4'
+gem 'puppet', '>= 7', '< 9'
 gem 'racc', '~> 1.8' if RUBY_VERSION >= '3.3'
 gem 'syslog', '~> 0.3' if RUBY_VERSION >= '3.4'

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'puppet'
 require 'facter'
 require 'facterdb'
 require 'json'
@@ -254,11 +253,20 @@ module RspecPuppetFacts
   def self.common_facts
     return @common_facts if @common_facts
 
+    # from Facter itself
     @common_facts = {
-      puppetversion: Puppet.version,
       rubysitedir: RbConfig::CONFIG['sitelibdir'],
       rubyversion: RUBY_VERSION,
     }
+
+    begin
+      require 'puppet'
+    rescue LoadError
+      warning 'Could not load Puppet'
+    else
+      # from Puppet.initialize_facts
+      @common_facts[:puppetversion] = Puppet.version.to_s
+    end
 
     @common_facts[:mco_version] = MCollective::VERSION if mcollective?
 
@@ -418,6 +426,13 @@ module RspecPuppetFacts
 end
 
 RSpec.configure do |c|
-  c.add_setting :default_facter_version, default: RspecPuppetFacts.facter_version_for_puppet_version(Puppet.version)
+  begin
+    require 'puppet'
+  rescue LoadError
+    puppet_version = nil
+  else
+    puppet_version = Puppet.version
+  end
+  c.add_setting :default_facter_version, default: RspecPuppetFacts.facter_version_for_puppet_version(puppet_version)
   c.add_setting :facterdb_string_keys, default: false
 end

--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'deep_merge', '~> 1.2'
   s.add_dependency 'facter', '< 5'
   s.add_dependency 'facterdb', '~> 3.1'
-  s.add_dependency 'puppet', '>= 7', '< 9'
 end


### PR DESCRIPTION
By making Puppet a soft dependency it becomes easy to use either OpenVox or Puppet.