### PR TITLE
Support OpenVox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,12 @@ group :release do
   gem 'github_changelog_generator', '~> 1.16.4', require: false
 end
 
-# openvox on Ruby 3.3 / 3.4 has some missing dependencies
-# Will be fixed in a future openvox release
-gem 'base64', '~> 0.2' if RUBY_VERSION >= '3.4'
-gem 'puppet', '>= 7', '< 9'
-gem 'racc', '~> 1.8' if RUBY_VERSION >= '3.3'
+if ENV.fetch('IMPLEMENTATION', nil) == 'puppet'
+  # puppet on Ruby 3.3 / 3.4 has some missing dependencies
+  gem 'base64', '~> 0.2' if RUBY_VERSION >= '3.4'
+  gem 'puppet', '>= 7', '< 9'
+  gem 'racc', '~> 1.8' if RUBY_VERSION >= '3.3'
+else
+  gem 'openvox'
+end
 gem 'syslog', '~> 0.3' if RUBY_VERSION >= '3.4'

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -266,6 +266,8 @@ module RspecPuppetFacts
     else
       # from Puppet.initialize_facts
       @common_facts[:puppetversion] = Puppet.version.to_s
+      # from Puppet::Node::Facts#add_local_facts
+      @common_facts[:implementation] = Puppet.implementation if Puppet.respond_to?(:implementation)
     end
 
     @common_facts[:mco_version] = MCollective::VERSION if mcollective?


### PR DESCRIPTION
The implementation fact is set if supported. Currently that's only OpenVox.

To test with Puppet you can set the IMPLEMENTATION environment variable.

Resubmission of https://github.com/voxpupuli/rspec-puppet-facts/pull/214